### PR TITLE
Refactor example app with modular demos

### DIFF
--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/Component/CloseButtonExampleView.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/Component/CloseButtonExampleView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct CloseButtonExampleView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Tap the close button to dismiss this view")
+            CloseButton()
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    CloseButtonExampleView()
+}

--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/ContentView.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/ContentView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import SwiftData
 
 struct ContentView: View {
     var body: some View {

--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/ContentView.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/ContentView.swift
@@ -1,151 +1,32 @@
-//
-//  ContentView.swift
-//  SwiftUtilitiesExample
-//
-//  Created by Hiromu Nakano on 2025/08/09.
-//
-
 import SwiftUI
-import SwiftData
 
 struct ContentView: View {
-    @Environment(\.modelContext) private var modelContext
-    @Query private var items: [Item]
-
-    @State private var randomColor: Color = .random()
-    @State private var adjustValue: Int = 0 {
-        didSet {
-            adjustedColor = randomColor.adjusted(by: adjustValue)
-        }
-    }
-    @State private var showHiddenSample: Bool = true
-    @State private var fetchedItem: Item? = nil
-    @State private var adjustedColor: Color = .random()
-    @State private var appIcon: UIImage? = UIImage.appIcon
-
     var body: some View {
-        NavigationSplitView {
+        NavigationStack {
             List {
-                Section(header: Text("パッケージ機能サンプル")) {
-                    // Color.random() サンプル
-                    HStack {
-                        Text("Random Color")
-                        Spacer()
-                        Circle()
-                            .fill(randomColor)
-                            .frame(width: 32, height: 32)
-                        Button("Change") {
-                            randomColor = Color.random()
-                            adjustedColor = randomColor.adjusted(by: adjustValue)
-                        }
-                    }
-                    // Color.adjusted サンプル
-                    HStack {
-                        Text("Adjusted Color")
-                        Spacer()
-                        Circle()
-                            .fill(adjustedColor)
-                            .frame(width: 32, height: 32)
-                        Stepper(value: $adjustValue, in: -30...30) {
-                            Text("")
-                        }
-                    }
-                    // UIImage.appIcon サンプル
-                    HStack {
-                        Text("App Icon")
-                        Spacer()
-                        if let icon = appIcon {
-                            Image(uiImage: icon)
-                                .resizable()
-                                .frame(width: 32, height: 32)
-                                .clipShape(RoundedRectangle(cornerRadius: 8))
-                        } else {
-                            Text("-")
-                        }
-                    }
-                    // CloseButton サンプル
-                    NavigationLink("CloseButton Demo") {
-                        VStack {
-                            Text("CloseButton 動作確認")
-                            CloseButton()
-                        }
-                        .padding()
-                    }
-                    // View.hidden サンプル
-                    HStack {
-                        Text("hidden(_:) Sample")
-                        Spacer()
-                        if showHiddenSample {
-                            Text("Visible")
-                        }
-                        Button(showHiddenSample ? "Hide" : "Show") {
-                            showHiddenSample.toggle()
-                        }
-                    }
-                    // ModelContext.fetchFirst/fetchRandom サンプル
-                    HStack {
-                        Button("Fetch First") {
-                            fetchFirstItem()
-                        }
-                        Button("Fetch Random") {
-                            fetchRandomItem()
-                        }
-                    }
-                    if let fetchedItem = fetchedItem {
-                        Text("Fetched: \(fetchedItem.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))")
-                    }
+                Section("Component") {
+                    NavigationLink("CloseButton") { CloseButtonExampleView() }
                 }
-
-                Section(header: Text("Item List")) {
-                    ForEach(items) { item in
-                        NavigationLink {
-                            Text("Item at \(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))")
-                        } label: {
-                            Text(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))
-                        }
-                    }
-                    .onDelete(perform: deleteItems)
+                Section("Extension") {
+                    NavigationLink("Color") { ColorExtensionExampleView() }
+                    NavigationLink("Collection") { CollectionExtensionExampleView() }
+                    NavigationLink("Image") { ImageExtensionExampleView() }
+                    NavigationLink("ModelContext") { ModelContextExtensionExampleView() }
+                    NavigationLink("Numeric") { NumericExtensionExampleView() }
+                    NavigationLink("Optional") { OptionalExtensionExampleView() }
+                    NavigationLink("PersistentIdentifier") { PersistentIdentifierExtensionExampleView() }
+                    NavigationLink("PersistentModel") { PersistentModelExtensionExampleView() }
+                    NavigationLink("StringProtocol") { StringProtocolExtensionExampleView() }
+                    NavigationLink("UIImage") { UIImageExtensionExampleView() }
+                    NavigationLink("View") { ViewExtensionExampleView() }
+                }
+                Section("Model") {
+                    NavigationLink("IntentPerformer") { IntentPerformerExampleView() }
+                    NavigationLink("SwiftUtilitiesError") { SwiftUtilitiesErrorExampleView() }
                 }
             }
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    EditButton()
-                }
-                ToolbarItem {
-                    Button(action: addItem) {
-                        Label("Add Item", systemImage: "plus")
-                    }
-                }
-            }
-            .onAppear {
-                appIcon = UIImage.appIcon
-            }
-        } detail: {
-            Text("Select an item")
+            .navigationTitle("SwiftUtilities Examples")
         }
-    }
-
-    private func addItem() {
-        withAnimation {
-            let newItem = Item(timestamp: Date())
-            modelContext.insert(newItem)
-        }
-    }
-
-    private func deleteItems(offsets: IndexSet) {
-        withAnimation {
-            for index in offsets {
-                modelContext.delete(items[index])
-            }
-        }
-    }
-
-    private func fetchFirstItem() {
-        fetchedItem = try? modelContext.fetchFirst(FetchDescriptor<Item>())
-    }
-
-    private func fetchRandomItem() {
-        fetchedItem = try? modelContext.fetchRandom(FetchDescriptor<Item>())
     }
 }
 

--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/CollectionExtensionExampleView.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/CollectionExtensionExampleView.swift
@@ -5,7 +5,7 @@ struct CollectionExtensionExampleView: View {
 
     var body: some View {
         VStack(spacing: 8) {
-            Text("Array.empty.count: \(Array<Int>.empty.count)")
+            Text("Array.empty.count: \([Int].empty.count)")
             Text("array.isNotEmpty: \(array.isNotEmpty.description)")
         }
         .padding()

--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/CollectionExtensionExampleView.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/CollectionExtensionExampleView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct CollectionExtensionExampleView: View {
+    let array = [1, 2, 3]
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Text("Array.empty.count: \(Array<Int>.empty.count)")
+            Text("array.isNotEmpty: \(array.isNotEmpty.description)")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    CollectionExtensionExampleView()
+}

--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/ColorExtensionExampleView.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/ColorExtensionExampleView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct ColorExtensionExampleView: View {
+    @State private var randomColor: Color = .random()
+    @State private var adjustValue: Int = 0
+    @State private var adjustedColor: Color = .random()
+
+    var body: some View {
+        VStack(spacing: 16) {
+            HStack {
+                Text("Random Color")
+                Spacer()
+                Circle()
+                    .fill(randomColor)
+                    .frame(width: 32, height: 32)
+                Button("Change") {
+                    randomColor = .random()
+                    adjustedColor = randomColor.adjusted(by: adjustValue)
+                }
+            }
+            HStack {
+                Text("Adjusted Color")
+                Spacer()
+                Circle()
+                    .fill(adjustedColor)
+                    .frame(width: 32, height: 32)
+                Stepper(value: $adjustValue, in: -30...30) {
+                    Text("")
+                }
+                .onChange(of: adjustValue) { _, newValue in
+                    adjustedColor = randomColor.adjusted(by: newValue)
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ColorExtensionExampleView()
+}

--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/ImageExtensionExampleView.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/ImageExtensionExampleView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct ImageExtensionExampleView: View {
+    private let data = UIImage(systemName: "star")!.pngData() ?? Data()
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(data: data)
+                .resizable()
+                .frame(width: 64, height: 64)
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ImageExtensionExampleView()
+}

--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/ModelContextExtensionExampleView.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/ModelContextExtensionExampleView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+import SwiftData
+
+struct ModelContextExtensionExampleView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query private var items: [Item]
+    @State private var fetchedItem: Item?
+
+    var body: some View {
+        VStack(spacing: 16) {
+            HStack {
+                Button("Add Item") {
+                    let newItem = Item(timestamp: Date())
+                    modelContext.insert(newItem)
+                }
+                Button("Fetch First") {
+                    fetchedItem = try? modelContext.fetchFirst(FetchDescriptor<Item>())
+                }
+                Button("Fetch Random") {
+                    fetchedItem = try? modelContext.fetchRandom(FetchDescriptor<Item>())
+                }
+            }
+            if let fetchedItem {
+                Text("Fetched: \(fetchedItem.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))")
+            }
+            List {
+                ForEach(items) { item in
+                    Text(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))
+                }
+                .onDelete { indexSet in
+                    for index in indexSet {
+                        modelContext.delete(items[index])
+                    }
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ModelContextExtensionExampleView()
+        .modelContainer(for: Item.self, inMemory: true)
+}

--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/NumericExtensionExampleView.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/NumericExtensionExampleView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct NumericExtensionExampleView: View {
+    var body: some View {
+        VStack(spacing: 8) {
+            Text("0.isZero: \(0.isZero.description)")
+            Text("1.isNotZero: \(1.isNotZero.description)")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    NumericExtensionExampleView()
+}

--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/OptionalExtensionExampleView.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/OptionalExtensionExampleView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct OptionalExtensionExampleView: View {
+    let optionalString: String? = "Hello"
+    let emptyOptional: String? = nil
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Text("optionalString.isNotEmpty: \(optionalString.isNotEmpty.description)")
+            Text("emptyOptional.orEmpty: \(emptyOptional.orEmpty)")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    OptionalExtensionExampleView()
+}

--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/PersistentIdentifierExtensionExampleView.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/PersistentIdentifierExtensionExampleView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct PersistentIdentifierExtensionExampleView: View {
+    var body: some View {
+        Text("Encoding/decoding PersistentIdentifier requires a SwiftData model instance.")
+            .padding()
+    }
+}
+
+#Preview {
+    PersistentIdentifierExtensionExampleView()
+}

--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/PersistentModelExtensionExampleView.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/PersistentModelExtensionExampleView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import SwiftData
+
+struct PersistentModelExtensionExampleView: View {
+    @Environment(\.modelContext) private var modelContext
+    @State private var item: Item?
+
+    var body: some View {
+        VStack(spacing: 16) {
+            if let item {
+                Text("Item created at \(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))")
+                Button("Delete Item") {
+                    item.delete()
+                    self.item = nil
+                }
+            } else {
+                Button("Create Item") {
+                    let newItem = Item(timestamp: Date())
+                    modelContext.insert(newItem)
+                    item = newItem
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    PersistentModelExtensionExampleView()
+        .modelContainer(for: Item.self, inMemory: true)
+}

--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/StringProtocolExtensionExampleView.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/StringProtocolExtensionExampleView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct StringProtocolExtensionExampleView: View {
+    let source = "ＡＢＣｄｅｆ"
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Text("Source: \(source)")
+            Text("Contains 'abc': \(source.normalizedContains("abc").description)")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    StringProtocolExtensionExampleView()
+}

--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/UIImageExtensionExampleView.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/UIImageExtensionExampleView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct UIImageExtensionExampleView: View {
+    @State private var appIcon: UIImage? = UIImage.appIcon
+
+    var body: some View {
+        VStack(spacing: 16) {
+            if let icon = appIcon {
+                Image(uiImage: icon)
+                    .resizable()
+                    .frame(width: 80, height: 80)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            } else {
+                Text("No App Icon")
+            }
+            Button("Reload") {
+                appIcon = UIImage.appIcon
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    UIImageExtensionExampleView()
+}

--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/ViewExtensionExampleView.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/Extension/ViewExtensionExampleView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct ViewExtensionExampleView: View {
+    @State private var isHidden: Bool = false
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("This text can be hidden")
+                .hidden(isHidden)
+            Button(isHidden ? "Show" : "Hide") {
+                isHidden.toggle()
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ViewExtensionExampleView()
+}

--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/Item.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/Item.swift
@@ -11,7 +11,7 @@ import SwiftData
 @Model
 final class Item {
     var timestamp: Date
-    
+
     init(timestamp: Date) {
         self.timestamp = timestamp
     }

--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/Model/IntentPerformerExampleView.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/Model/IntentPerformerExampleView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct EchoPerformer: IntentPerformer {
+    static func perform(_ input: String) async throws -> String {
+        input
+    }
+}
+
+struct IntentPerformerExampleView: View {
+    @State private var output: String = ""
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Button("Perform") {
+                Task {
+                    output = (try? await EchoPerformer.perform("hello")) ?? ""
+                }
+            }
+            Text(output)
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    IntentPerformerExampleView()
+}

--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/Model/SwiftUtilitiesErrorExampleView.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/Model/SwiftUtilitiesErrorExampleView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+import SwiftData
+
+struct SwiftUtilitiesErrorExampleView: View {
+    @State private var message: String = ""
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Button("Trigger Error") {
+                do {
+                    _ = try PersistentIdentifier(base64Encoded: "invalid")
+                } catch {
+                    message = String(describing: error)
+                }
+            }
+            Text(message)
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    SwiftUtilitiesErrorExampleView()
+}

--- a/SwiftUtilitiesExample/SwiftUtilitiesExample/SwiftUtilitiesExampleApp.swift
+++ b/SwiftUtilitiesExample/SwiftUtilitiesExample/SwiftUtilitiesExampleApp.swift
@@ -12,7 +12,7 @@ import SwiftData
 struct SwiftUtilitiesExampleApp: App {
     var sharedModelContainer: ModelContainer = {
         let schema = Schema([
-            Item.self,
+            Item.self
         ])
         let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 


### PR DESCRIPTION
## Summary
- Split example app into Component, Extension, and Model sections
- Added dedicated SwiftUI views to demonstrate each utility file
- Removed redundant `import SwiftUtilities` statements from example views

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6896ac7e82d8832084b085ad8761a34a